### PR TITLE
Reorganized imports (power was missing)

### DIFF
--- a/microbit/__init__.py
+++ b/microbit/__init__.py
@@ -1,15 +1,22 @@
+# Basics
 import accelerometer
-import audio
 import compass
 import display
 import i2c
 import microphone
-import neopixel
-import radio
+import power
 import speaker
-import speech
 import spi
 import uart
+# Extended
+import audio
+import machine
+import music
+import neopixel
+import os
+import radio
+import random
+import speech
 
 #Functions
 


### PR DESCRIPTION
Hi Toby,
there seems to be [a problem](https://github.com/makinteract/vscode-microbit-micropython/issues/5) with stubs imports. I think that one of the imports (power) was missing from the list. I also have reorganized them, so that it is clear which imports are from the basic stubs and which are from the extended ones.